### PR TITLE
Reorder draw depths

### DIFF
--- a/Content.Shared/DrawDepth/DrawDepth.cs
+++ b/Content.Shared/DrawDepth/DrawDepth.cs
@@ -110,13 +110,13 @@ namespace Content.Shared.DrawDepth
         BlastDoors = DrawDepthTag.Default + 9,
 
         // Begin Stellar - These go over mobs
-        Walls = DrawDepthTag.Default + 10,
+        Walls = DrawDepthTag.Default + 6,
 
         /// <summary>
         ///     Used for windows (grilles use walls) and misc signage. Useful if you want to have an APC in the middle
         ///     of some wall-art or something.
         /// </summary>
-        WallTops = DrawDepthTag.Default + 11,
+        WallTops = DrawDepthTag.Default + 6,
         // End Stellar - These go over mobs
 
         /// <summary>

--- a/Content.Shared/DrawDepth/DrawDepth.cs
+++ b/Content.Shared/DrawDepth/DrawDepth.cs
@@ -56,13 +56,15 @@ namespace Content.Shared.DrawDepth
         /// </summary>
         SmallMobs = DrawDepthTag.Default - 3,
 
-        Walls = DrawDepthTag.Default - 2,
+        // Begin Stellar - These go over mobs
+        // Walls = DrawDepthTag.Default - 2,
 
-        /// <summary>
-        ///     Used for windows (grilles use walls) and misc signage. Useful if you want to have an APC in the middle
-        ///     of some wall-art or something.
-        /// </summary>
-        WallTops = DrawDepthTag.Default - 1,
+        // /// <summary>
+        // ///     Used for windows (grilles use walls) and misc signage. Useful if you want to have an APC in the middle
+        // ///     of some wall-art or something.
+        // /// </summary>
+        // WallTops = DrawDepthTag.Default - 1,
+        // End Stellar - These go over mobs
 
         /// <summary>
         ///     Furniture, crates, tables. etc. If an entity should be drawn on top of a table, it needs a draw depth
@@ -107,22 +109,32 @@ namespace Content.Shared.DrawDepth
         /// </summary>
         BlastDoors = DrawDepthTag.Default + 9,
 
+        // Begin Stellar - These go over mobs
+        Walls = DrawDepthTag.Default + 10,
+
+        /// <summary>
+        ///     Used for windows (grilles use walls) and misc signage. Useful if you want to have an APC in the middle
+        ///     of some wall-art or something.
+        /// </summary>
+        WallTops = DrawDepthTag.Default + 11,
+        // End Stellar - These go over mobs
+
         /// <summary>
         /// Stuff that needs to draw over most things, but not effects, like Kudzu.
         /// </summary>
-        Overdoors = DrawDepthTag.Default + 10,
+        Overdoors = DrawDepthTag.Default + 12, // Stellar - Reorder
 
         /// <summary>
         ///     Explosions, fire, melee swings. Whatever.
         /// </summary>
-        Effects = DrawDepthTag.Default + 11,
+        Effects = DrawDepthTag.Default + 13, // Stellar - Reorder
 
-        Ghosts = DrawDepthTag.Default + 12,
+        Ghosts = DrawDepthTag.Default + 14, // Stellar - Reorder
 
         /// <summary>
         ///    Use this selectively if it absolutely needs to be drawn above (almost) everything else. Examples include
         ///    the pointing arrow, the drag & drop ghost-entity, and some debug tools.
         /// </summary>
-        Overlays = DrawDepthTag.Default + 13,
+        Overlays = DrawDepthTag.Default + 15, // Stellar - Reorder
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -588,7 +588,6 @@
   - type: Sprite
     # Begin Stellar - Wallening
     sprite: _ST/Tileset/Walls/metal_reinforced.rsi
-    drawdepth: Mobs
   - type: SpriteFade
   - type: Icon
     sprite: _ST/Tileset/Walls/metal_reinforced.rsi
@@ -986,7 +985,6 @@
   - type: Sprite
     # Begin Stellar - Wallening
     sprite: _ST/Tileset/Walls/metal.rsi
-    drawdepth: Mobs
   - type: SpriteFade
     # End Stellar - Wallening
   - type: WallReplacementMarker


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
reorder draw depths in c#

## Why / Balance
walls are not mobs
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
reorder an enum

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Walls are no longer mobs
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
