### PR TITLE
Update Content.Stellar.* to be zero warnings

### DIFF
--- a/Content.Stellar.Client/Content.Stellar.Client.csproj
+++ b/Content.Stellar.Client/Content.Stellar.Client.csproj
@@ -6,6 +6,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>..\bin\Content.Client\</OutputPath>
     <WarningsAsErrors>RA0032;nullable</WarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Tools;DebugOpt</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/Content.Stellar.Client/CosmicCult/MonumentVisualsSystem.cs
+++ b/Content.Stellar.Client/CosmicCult/MonumentVisualsSystem.cs
@@ -9,6 +9,7 @@ namespace Content.Stellar.Client.CosmicCult;
 public sealed class MonumentVisualizerSystem : EntitySystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -21,24 +22,24 @@ public sealed class MonumentVisualizerSystem : EntitySystem
     {
         if (args.Sprite == null)
             return;
-        args.Sprite.LayerMapTryGet(MonumentVisualLayers.TransformLayer, out var transformLayer);
-        args.Sprite.LayerMapTryGet(MonumentVisualLayers.MonumentLayer, out var baseLayer);
+        _sprite.LayerMapTryGet(ent.Owner, MonumentVisualLayers.TransformLayer, out var transformLayer, true);
+        _sprite.LayerMapTryGet(ent.Owner, MonumentVisualLayers.MonumentLayer, out var baseLayer, true);
         _appearance.TryGetData<bool>(ent, MonumentVisuals.Transforming, out var transforming, args.Component);
         _appearance.TryGetData<bool>(ent, MonumentVisuals.Tier3, out var tier3, args.Component);
         if (!tier3)
-            args.Sprite.LayerSetState(transformLayer, "transform-stage2");
+            _sprite.LayerSetRsiState(ent.Owner, transformLayer, "transform-stage2");
         else
-            args.Sprite.LayerSetState(transformLayer, "transform-stage3");
+            _sprite.LayerSetRsiState(ent.Owner, transformLayer, "transform-stage3");
         if (transforming && HasComp<MonumentTransformingComponent>(ent))
         {
-            args.Sprite.LayerSetAnimationTime(transformLayer, 0f);
-            args.Sprite.LayerSetVisible(transformLayer, true);
-            args.Sprite.LayerSetVisible(baseLayer, false);
+            _sprite.LayerSetAnimationTime(ent.Owner, transformLayer, 0f);
+            _sprite.LayerSetVisible(ent.Owner, transformLayer, true);
+            _sprite.LayerSetVisible(ent.Owner, baseLayer, false);
         }
         else
         {
-            args.Sprite.LayerSetVisible(transformLayer, false);
-            args.Sprite.LayerSetVisible(baseLayer, true);
+            _sprite.LayerSetVisible(ent.Owner, transformLayer, false);
+            _sprite.LayerSetVisible(ent.Owner, baseLayer, true);
         }
     }
 }

--- a/Content.Stellar.Client/CosmicCult/UI/Monument/InfluenceUIBox.xaml
+++ b/Content.Stellar.Client/CosmicCult/UI/Monument/InfluenceUIBox.xaml
@@ -9,7 +9,7 @@
             <BoxContainer Orientation="Horizontal" Margin="0 0 0 10">
                 <TextureRect Name="InfluenceIcon" VerticalAlignment="Center" TextureScale="2 2" Stretch="KeepCentered" Margin="0 0 10 0" />
                 <BoxContainer Orientation="Vertical" HorizontalExpand="True">
-                    <Label Name="Name" HorizontalAlignment="Left" FontColorOverride="#4CA7AD" />
+                    <Label Name="InfluenceName" HorizontalAlignment="Left" FontColorOverride="#4CA7AD" />
                     <PanelContainer StyleClasses="LowDivider" MinHeight="4" Margin="0 5 0 5" />
                     <BoxContainer VerticalAlignment="Center">
                         <Label Name="Status" HorizontalAlignment="Left" HorizontalExpand="True" />

--- a/Content.Stellar.Client/CosmicCult/UI/Monument/InfluenceUIBox.xaml.cs
+++ b/Content.Stellar.Client/CosmicCult/UI/Monument/InfluenceUIBox.xaml.cs
@@ -37,7 +37,7 @@ public sealed partial class InfluenceUIBox : BoxContainer
         GainButton.StyleClasses.Add("ButtonColorPurpleAndCool");
 
         InfluenceIcon.Texture = _sprite.Frame0(influenceProto.Icon);
-        Name.Text = Loc.GetString(influenceProto.Name);
+        InfluenceName.Text = Loc.GetString(influenceProto.Name);
 
         State = state;
         Proto = influenceProto;
@@ -84,7 +84,7 @@ public sealed partial class InfluenceUIBox : BoxContainer
                 GainButton.Label.Text = Loc.GetString("monument-interface-influences-locked");
                 GainButton.ToolTip = Loc.GetString("monument-interface-influences-locked-tooltip");
 
-                Name.FontColorOverride = Color.White;
+                InfluenceName.FontColorOverride = Color.White;
 
                 InfluenceBox.Modulate = Color.Gray;
                 InfluenceIcon.Modulate = Color.Gray;

--- a/Content.Stellar.Client/CosmicCult/Visuals/MonumentPlacementPreviewSystem.cs
+++ b/Content.Stellar.Client/CosmicCult/Visuals/MonumentPlacementPreviewSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.Actions.Components;
 using Content.Shared.Actions.Events;
 using Content.Shared.Actions;
 using Content.Shared.Maps;
-using Content.Shared.Maps;
 using Content.Stellar.Shared.CosmicCult.Components;
 using Content.Stellar.Shared.CosmicCult;
 using Robust.Client.GameObjects;

--- a/Content.Stellar.Server/Content.Stellar.Server.csproj
+++ b/Content.Stellar.Server/Content.Stellar.Server.csproj
@@ -9,6 +9,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <NoWarn>1998</NoWarn>
     <WarningsAsErrors>RA0032;nullable</WarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>

--- a/Content.Stellar.Server/CosmicCult/Abilities/CosmicConversionSystem.cs
+++ b/Content.Stellar.Server/CosmicCult/Abilities/CosmicConversionSystem.cs
@@ -17,7 +17,6 @@ public sealed class CosmicConversionSystem : EntitySystem
     [Dependency] private readonly CosmicCultRuleSystem _cultRule = default!;
     [Dependency] private readonly CosmicGlyphSystem _cosmicGlyph = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SharedCosmicCultSystem _cosmicCult = default!;

--- a/Content.Stellar.Server/CosmicCult/Abilities/CosmicSiphonSystem.cs
+++ b/Content.Stellar.Server/CosmicCult/Abilities/CosmicSiphonSystem.cs
@@ -10,7 +10,7 @@ using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.NPC;
 using Content.Shared.Popups;
-using Content.Shared.StatusEffect;
+using Content.Shared.StatusEffectNew;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 
@@ -24,9 +24,8 @@ public sealed class CosmicSiphonSystem : EntitySystem
     [Dependency] private readonly GhostSystem _ghost = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
-    [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private readonly SharedStatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly CosmicCultSystem _cosmicCult = default!;
 
     private readonly HashSet<Entity<PoweredLightComponent>> _lights = [];
@@ -82,7 +81,7 @@ public sealed class CosmicSiphonSystem : EntitySystem
         uid.Comp.EntropyBudget += uid.Comp.CosmicSiphonQuantity;
         Dirty(uid, uid.Comp);
 
-        _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(target, "EntropicDegen", TimeSpan.FromSeconds(21), true);
+        _statusEffects.TryAddStatusEffectDuration(target, "EntropicDegen", out _, TimeSpan.FromSeconds(21));
         if (_cosmicCult.EntityIsCultist(target))
         {
             _popup.PopupEntity(Loc.GetString("cosmicability-siphon-cultist-success", ("target", Identity.Entity(target, EntityManager))), uid, uid);

--- a/Content.Stellar.Server/CosmicCult/CosmicCultSystem.cs
+++ b/Content.Stellar.Server/CosmicCult/CosmicCultSystem.cs
@@ -15,7 +15,7 @@ using Content.Shared.Hands;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
-using Content.Shared.StatusEffect;
+using Content.Shared.StatusEffectNew;
 using Content.Stellar.Server.CosmicCult.EntitySystems;
 using Content.Stellar.Shared.CosmicCult.Components;
 using Content.Stellar.Shared.CosmicCult;
@@ -53,12 +53,12 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly StationSystem _station = default!;
-    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private readonly SharedStatusEffectsSystem _statusEffects = default!;
 
     private readonly ResPath _mapPath = new("Maps/_ST/Other/cosmicvoid.yml");
 
     private static readonly EntProtoId CosmicEchoVfx = "CosmicEchoVfx";
-    private static readonly ProtoId<StatusEffectPrototype> EntropicDegen = "EntropicDegen";
+    private static readonly EntProtoId EntropicDegen = "EntropicDegen";
 
     public override void Initialize()
     {
@@ -156,7 +156,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
     private void OnGotEquipped(Entity<CosmicEquipmentComponent> ent, ref GotEquippedEvent args)
     {
         if (!EntityIsCultist(args.Equipee))
-            _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(args.Equipee, EntropicDegen, TimeSpan.FromDays(1), true); // TimeSpan.MaxValue causes a crash here, so we use FromDays(1) instead.
+            _statusEffects.TrySetStatusEffectDuration(args.Equipee, EntropicDegen, out _);
     }
 
     private void OnGotUnequipped(Entity<CosmicEquipmentComponent> ent, ref GotUnequippedEvent args)
@@ -168,7 +168,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
     {
         if (!EntityIsCultist(args.User))
         {
-            _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(args.User, EntropicDegen, TimeSpan.FromDays(1), true);
+            _statusEffects.TrySetStatusEffectDuration(args.User, EntropicDegen, out _);
             _popup.PopupEntity(Loc.GetString("cosmiccult-gear-pickup", ("ITEM", args.Equipped)), args.User, args.User, PopupType.MediumCaution);
         }
     }

--- a/Content.Stellar.Server/CosmicCult/DeconversionSystem.cs
+++ b/Content.Stellar.Server/CosmicCult/DeconversionSystem.cs
@@ -21,15 +21,12 @@ namespace Content.Stellar.Server.CosmicCult;
 public sealed class DeconversionSystem : EntitySystem
 {
     [Dependency] private readonly DamageableSystem _damageable = default!;
-    [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedJitteringSystem _jittering = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedToolSystem _tools = default!;
-    [Dependency] private readonly UseDelaySystem _delay = default!;
 
     public override void Initialize()
     {

--- a/Content.Stellar.Shared/Content.Stellar.Shared.csproj
+++ b/Content.Stellar.Shared/Content.Stellar.Shared.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <WarningsAsErrors>RA0032;nullable</WarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/Content.Stellar.Shared/CosmicCult/Components/CosmicEntropyDebuffStatusEffectComponent.cs
+++ b/Content.Stellar.Shared/CosmicCult/Components/CosmicEntropyDebuffStatusEffectComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Stellar.Shared.CosmicCult.Components;
 /// </summary>
 [RegisterComponent]
 [AutoGenerateComponentPause]
-public sealed partial class CosmicEntropyDebuffComponent : Component
+public sealed partial class CosmicEntropyDebuffStatusEffectComponent : Component
 {
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoPausedField]

--- a/Content.Stellar.Shared/CosmicCult/SharedMonumentSystem.cs
+++ b/Content.Stellar.Shared/CosmicCult/SharedMonumentSystem.cs
@@ -118,7 +118,7 @@ public abstract class SharedMonumentSystem : EntitySystem
         if (!_prototype.TryIndex(args.InfluenceProtoId, out var proto) || !TryComp<ActivatableUIComponent>(ent, out var uiComp) || !TryComp<CosmicCultComponent>(args.Actor, out var cultComp))
             return;
 
-        if (cultComp.EntropyBudget < proto.Cost || cultComp.OwnedInfluences.Contains(proto) || args.Actor == null)
+        if (cultComp.EntropyBudget < proto.Cost || cultComp.OwnedInfluences.Contains(proto))
             return;
 
         cultComp.OwnedInfluences.Add(proto);

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1432,7 +1432,7 @@
       methods: [ Touch ]
       effects:
       - !type:WashCreamPieReaction
-
+  - type: CosmicCenserTarget # Stellar - Cosmic Cult
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -210,6 +210,7 @@
     - FootstepSound
     - DoorBumpOpener
     - AnomalyHost
+  - type: CosmicCenserTarget # Stellar - Cosmic Cult
 
 - type: entity
   save: false

--- a/Resources/Prototypes/_ST/CosmicCult/status_effects.yml
+++ b/Resources/Prototypes/_ST/CosmicCult/status_effects.yml
@@ -1,3 +1,6 @@
-- type: statusEffect
+- type: entity
+  parent: MobStatusEffectBase
   id: EntropicDegen
-  alwaysAllowed: true
+  name: entropic degeneration
+  components:
+  - type: CosmicEntropyDebuffStatusEffect


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Technical details
- use spritesystem instead of sprite methods in client
- use new status effects system for cosmic cult
- enable errors on warnings in content.stellar.* for now

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

