### PR TITLE
Unify Stellar windoors into the Wizden windoors hierarchy

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
@@ -1,12 +1,12 @@
 - type: entity
   id: Windoor
-  parent: BaseWindoor
+  parent: StellarWindoorGlass # Stellar - unify the windoors
   name: windoor
   description: It's a window and a sliding door. Wow!
 
 - type: entity
   id: WindoorSecure
-  parent: BaseSecureWindoor
+  parent: StellarWindoorGlassReinforced # Stellar - unify the windoors
   name: secure windoor
   description: It's a sturdy window and a sliding door. Wow!
 
@@ -18,25 +18,25 @@
 
 - type: entity
   id: WindoorPlasma
-  parent: BasePlasmaWindoor
+  parent: StellarWindoorPlasma # Stellar - unify the windoors
   name: plasma windoor
   description: It's a pink window *and* a sliding door. Amazing!
 
 - type: entity
   id: WindoorSecurePlasma
-  parent: BaseSecurePlasmaWindoor
+  parent: StellarWindoorPlasmaReinforced # Stellar - unify the windoors
   name: secure plasma windoor
   description: It's a sturdy purple window *and* a sliding door. Spectacular!
 
 - type: entity
   id: WindoorUranium
-  parent: BaseUraniumWindoor
+  parent: StellarWindoorUranium # Stellar - unify the windoors
   name: uranium windoor
   description: It's a window and a sliding door. Huh? Oh, and it's green!
 
 - type: entity
   id: WindoorSecureUranium
-  parent: BaseSecureUraniumWindoor
+  parent: StellarWindoorUraniumReinforced # Stellar - unify the windoors
   name: secure uranium windoor
   description: It's a sturdy window and a sliding door. It's so neon green, it might even taste like limes!
 

--- a/Resources/Prototypes/_ST/Tests/windoors.yml
+++ b/Resources/Prototypes/_ST/Tests/windoors.yml
@@ -5,6 +5,7 @@
 - type: entity
   id: StellarWindoorGlass
   parent: BaseWindoor
+  abstract: true
   name: directional glass windoor
   description: A glass service door for installation on tables or countertops.
   components:
@@ -64,6 +65,7 @@
 - type: entity
   id: StellarWindoorGlassReinforced
   parent: StellarWindoorGlass
+  abstract: true
   name: reinforced directional glass windoor
   description: A glass service door for installation on tables or countertops. This one's a bit tougher.
   components:
@@ -75,6 +77,7 @@
 - type: entity
   id: StellarWindoorPlasma
   parent: StellarWindoorGlass
+  abstract: true
   name: directional plasma windoor
   description: A plasma glass service door for installation on tables or countertops.
   components:
@@ -84,6 +87,7 @@
 - type: entity
   id: StellarWindoorPlasmaReinforced
   parent: StellarWindoorGlassReinforced
+  abstract: true
   name: reinforced directional plasma windoor
   description: A plasma glass service door for installation on tables or countertops. This one's a bit tougher.
   components:
@@ -94,6 +98,7 @@
 - type: entity
   id: StellarWindoorUranium
   parent: StellarWindoorGlass
+  abstract: true
   name: directional uranium windoor
   description: A uranium glass service door for installation on tables or countertops.
   components:
@@ -103,6 +108,7 @@
 - type: entity
   id: StellarWindoorUraniumReinforced
   parent: StellarWindoorGlassReinforced
+  abstract: true
   name: reinforced directional uranium windoor
   description: A uranium glass service door for installation on tables or countertops. This one's a bit tougher.
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- stellar windoors are now the parents of wizden windoors

## Why / Balance
- not rewriting all of those prototypes

## Technical details
- swap some parents around

## Media
<img width="383" height="428" alt="grafik" src="https://github.com/user-attachments/assets/e37a221e-8065-4a81-8e68-1e473dd4e18b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
the `Stellar*` ID windoors are abstract now

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: All windoors are now Stellar windoors
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
