### PR TITLE
DoAfter Overlay Hotfix

### DIFF
--- a/Content.Client/DoAfter/DoAfterOverlay.cs
+++ b/Content.Client/DoAfter/DoAfterOverlay.cs
@@ -154,7 +154,7 @@ public sealed class DoAfterOverlay : Overlay
                 var xProgress = (EndX - StartX) * elapsedRatio + StartX;
                 var box = new Box2(new Vector2(StartX, StartY) / EyeManager.PixelsPerMeter, new Vector2(xProgress, ProgressY) / EyeManager.PixelsPerMeter); // Begin Stellar - Revamped DoAfters
                 var boxGlow = new Box2(new Vector2(StartX - 1f, StartY - 1f) / EyeManager.PixelsPerMeter, new Vector2(xProgress + 1f, ProgressY + 1f) / EyeManager.PixelsPerMeter);
-                var boxHighlight = new Box2(new Vector2(StartX, StartY + 1f) / EyeManager.PixelsPerMeter, new Vector2(xProgress, ProgressY - 2f) / EyeManager.PixelsPerMeter);
+                var boxHighlight = new Box2(new Vector2(StartX, StartY + 1f) / EyeManager.PixelsPerMeter, new Vector2(xProgress, ProgressY - 1f) / EyeManager.PixelsPerMeter);
                 box = box.Translated(position);
                 boxGlow = boxGlow.Translated(position);
                 boxHighlight = boxHighlight.Translated(position);


### PR DESCRIPTION
## About the PR
Fixes the DoAfter overlay glow to appear correctly.

## Why / Balance
Bug.

## Technical details
Changes a single number i mistyped in the DoAfterOverlaySystem.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Fixed the new DoAfters' glow.
