### PR TITLE
Port: Animation Easings & ClientInherent MobLights from Ephemeral Space

### DIFF
--- a/Content.Client/Animations/EntityPickupAnimationSystem.cs
+++ b/Content.Client/Animations/EntityPickupAnimationSystem.cs
@@ -68,7 +68,8 @@ public sealed class EntityPickupAnimationSystem : EntitySystem
 
         _animations.Play(new Entity<AnimationPlayerComponent>(animatableClone, animations), new Animation
         {
-            Length = TimeSpan.FromMilliseconds(125),
+            // ES START
+            Length = TimeSpan.FromMilliseconds(175),
             AnimationTracks =
             {
                 new AnimationTrackComponentProperty
@@ -79,10 +80,33 @@ public sealed class EntityPickupAnimationSystem : EntitySystem
                     KeyFrames =
                     {
                         new KeyFrame(initial.Position, 0),
-                        new KeyFrame(final, 0.125f)
+                        new KeyFrame(final, 0.175f, Easings.OutQuad)
+                    }
+                },
+                new AnimationTrackComponentProperty
+                {
+                    ComponentType = typeof(SpriteComponent),
+                    Property = nameof(SpriteComponent.Scale),
+                    InterpolationMode = AnimationInterpolationMode.Linear,
+                    KeyFrames =
+                    {
+                        new KeyFrame(sprite.Scale, 0),
+                        new KeyFrame(new Vector2(0.5f, 0.5f), 0.175f, Easings.OutQuad)
+                    }
+                },
+                new AnimationTrackComponentProperty
+                {
+                    ComponentType = typeof(SpriteComponent),
+                    Property = nameof(SpriteComponent.Color),
+                    InterpolationMode = AnimationInterpolationMode.Linear,
+                    KeyFrames =
+                    {
+                        new KeyFrame(sprite.Color, 0),
+                        new KeyFrame(sprite.Color.WithAlpha(0f), 0.175f, Easings.OutQuad)
                     }
                 },
             }
+            // ES END
         }, "fancy_pickup_anim");
     }
 }

--- a/Content.Client/Effects/ColorFlashEffectSystem.cs
+++ b/Content.Client/Effects/ColorFlashEffectSystem.cs
@@ -89,8 +89,12 @@ public sealed class ColorFlashEffectSystem : SharedColorFlashEffectSystem
                     InterpolationMode = AnimationInterpolationMode.Linear,
                     KeyFrames =
                     {
-                        new AnimationTrackProperty.KeyFrame(color, 0f),
-                        new AnimationTrackProperty.KeyFrame(sprite.Color, AnimationLength)
+                        // ES START
+                        // todo mirror this still looks like ass
+                        new AnimationTrackProperty.KeyFrame(sprite.Color, 0f),
+                        new AnimationTrackProperty.KeyFrame(color, AnimationLength * 0.3f, Easings.InSine),
+                        new AnimationTrackProperty.KeyFrame(sprite.Color, AnimationLength * 0.7f, Easings.OutSine)
+                        // ES END
                     }
                 }
             }

--- a/Content.Client/Gravity/FloatingVisualizerSystem.cs
+++ b/Content.Client/Gravity/FloatingVisualizerSystem.cs
@@ -40,9 +40,11 @@ public sealed class FloatingVisualizerSystem : SharedFloatingVisualizerSystem
                     InterpolationMode = AnimationInterpolationMode.Linear,
                     KeyFrames =
                     {
+                        // ES START
                         new AnimationTrackProperty.KeyFrame(Vector2.Zero, 0f),
-                        new AnimationTrackProperty.KeyFrame(offset, animationTime),
-                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, animationTime),
+                        new AnimationTrackProperty.KeyFrame(offset, animationTime, Easings.InOutSine),
+                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, animationTime, Easings.InOutSine),
+                        // ES END
                     }
                 }
             }

--- a/Content.Client/Light/EntitySystems/LightFadeSystem.cs
+++ b/Content.Client/Light/EntitySystems/LightFadeSystem.cs
@@ -29,14 +29,16 @@ public sealed class LightFadeSystem : EntitySystem
             {
                 new AnimationTrackComponentProperty()
                 {
+                    // ES START
                     Property = nameof(PointLightComponent.Energy),
                     ComponentType = typeof(PointLightComponent),
-                    InterpolationMode = AnimationInterpolationMode.Cubic,
+                    InterpolationMode = AnimationInterpolationMode.Linear,
                     KeyFrames =
                     {
                         new AnimationTrackProperty.KeyFrame(light.Energy, 0f),
-                        new AnimationTrackProperty.KeyFrame(0f, component.Duration)
+                        new AnimationTrackProperty.KeyFrame(0f, component.Duration, Easings.InOutCubic)
                     }
+                    // ES END
                 }
             }
         };

--- a/Content.Client/Pointing/PointingSystem.Visualizer.cs
+++ b/Content.Client/Pointing/PointingSystem.Visualizer.cs
@@ -41,23 +41,24 @@ public sealed partial class PointingSystem : SharedPointingSystem
                 {
                     ComponentType = typeof(SpriteComponent),
                     Property = nameof(SpriteComponent.Offset),
-                    InterpolationMode = AnimationInterpolationMode.Cubic,
+                    // ES START
+                    InterpolationMode = AnimationInterpolationMode.Linear,
                     KeyFrames =
                     {
                         // We pad here to prevent improper looping and tighten the overshoot, just a touch
                         new AnimationTrackProperty.KeyFrame(startPosition, 0f),
-                        new AnimationTrackProperty.KeyFrame(Vector2.Lerp(startPosition, offset, 0.9f), PointKeyTimeMove),
-                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeMove),
-                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeMove),
-                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover),
-                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover),
-                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover),
-                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover),
-                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover),
-                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover),
-                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover),
-                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover),
+                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeMove, Easings.OutCubic),
+                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover, Easings.InQuad),
+                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover, Easings.OutQuad),
+                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover, Easings.InQuad),
+                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover, Easings.OutQuad),
+                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover, Easings.InQuad),
+                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover, Easings.OutQuad),
+                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover, Easings.InQuad),
+                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover, Easings.OutQuad),
+                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover, Easings.InQuad),
                     }
+                    // ES END
                 }
             }
         };

--- a/Content.Client/Rotation/RotationVisualizerSystem.cs
+++ b/Content.Client/Rotation/RotationVisualizerSystem.cs
@@ -68,7 +68,9 @@ public sealed class RotationVisualizerSystem : SharedRotationVisualsSystem
                     KeyFrames =
                     {
                         new AnimationTrackProperty.KeyFrame(spriteComp.Rotation, 0),
-                        new AnimationTrackProperty.KeyFrame(rotation, animationTime)
+                        // ES START
+                        new AnimationTrackProperty.KeyFrame(rotation, animationTime, Easings.OutCubic)
+                        // ES END
                     }
                 }
             }

--- a/Content.Client/SubFloor/TrayScannerSystem.cs
+++ b/Content.Client/SubFloor/TrayScannerSystem.cs
@@ -126,7 +126,9 @@ public sealed class TrayScannerSystem : SharedTrayScannerSystem
                             KeyFrames =
                             {
                                 new AnimationTrackProperty.KeyFrame(sprite.Color.WithAlpha(0f), 0f),
-                                new AnimationTrackProperty.KeyFrame(sprite.Color.WithAlpha(SubfloorRevealAlpha), (float) AnimationLength)
+                                // ES START
+                                new AnimationTrackProperty.KeyFrame(sprite.Color.WithAlpha(SubfloorRevealAlpha), (float) AnimationLength, Easings.InQuad)
+                                // ES END
                             }
                         }
                     }
@@ -161,7 +163,9 @@ public sealed class TrayScannerSystem : SharedTrayScannerSystem
                             KeyFrames =
                             {
                                 new AnimationTrackProperty.KeyFrame(sprite.Color, 0f),
-                                new AnimationTrackProperty.KeyFrame(sprite.Color.WithAlpha(0f), (float) AnimationLength)
+                                // ES START
+                                new AnimationTrackProperty.KeyFrame(sprite.Color.WithAlpha(0f), (float) AnimationLength, Easings.OutQuad)
+                                // ES END
                             }
                         }
                     }

--- a/Content.Client/Throwing/ThrownItemVisualizerSystem.cs
+++ b/Content.Client/Throwing/ThrownItemVisualizerSystem.cs
@@ -63,7 +63,6 @@ public sealed class ThrownItemVisualizerSystem : EntitySystem
         var scale = ent.Comp2.Scale;
         var lenFloat = (float)length.TotalSeconds;
 
-        // TODO use like actual easings here
         return new Animation
         {
             Length = length,
@@ -75,9 +74,11 @@ public sealed class ThrownItemVisualizerSystem : EntitySystem
                     Property = nameof(SpriteComponent.Scale),
                     KeyFrames =
                     {
+                        // ES START
                         new AnimationTrackProperty.KeyFrame(scale, 0.0f),
-                        new AnimationTrackProperty.KeyFrame(scale * 1.4f, lenFloat * 0.25f),
-                        new AnimationTrackProperty.KeyFrame(scale, lenFloat * 0.75f)
+                        new AnimationTrackProperty.KeyFrame(scale * 1.4f, lenFloat * 0.5f, Easings.OutQuad),
+                        new AnimationTrackProperty.KeyFrame(scale, lenFloat * 0.5f, Easings.InQuad)
+                        // ES END
                     },
                     InterpolationMode = AnimationInterpolationMode.Linear
                 }

--- a/Content.Client/_ES/Lighting/ESInherentLightComponent.cs
+++ b/Content.Client/_ES/Lighting/ESInherentLightComponent.cs
@@ -1,0 +1,21 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._ES.Lighting;
+
+/// <summary>
+///     This is used for showing a clientside pointlight for your own controlled mob, like in SS13.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ESInherentLightComponent : Component
+{
+    [ViewVariables]
+    public EntityUid? LightEntity = null;
+
+    /// <summary>
+    ///     Prototype to spawn as the light entity.
+    ///     Should obviously have a pointlight of some kind, with netsync false, and disabled by default.
+    /// </summary>
+    [DataField]
+    public EntProtoId LightPrototype = "ESMobDefaultInherentLight";
+}

--- a/Content.Client/_ES/Lighting/ESInherentLightComponent.cs
+++ b/Content.Client/_ES/Lighting/ESInherentLightComponent.cs
@@ -1,4 +1,7 @@
-using Robust.Shared.GameStates;
+// SPDX-FileCopyrightText: 2025 Mirrorcult
+//
+// SPDX-License-Identifier: MIT
+
 using Robust.Shared.Prototypes;
 
 namespace Content.Client._ES.Lighting;

--- a/Content.Client/_ES/Lighting/ESInherentLightSystem.cs
+++ b/Content.Client/_ES/Lighting/ESInherentLightSystem.cs
@@ -1,0 +1,46 @@
+using System.Numerics;
+using Robust.Client.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+
+namespace Content.Client._ES.Lighting;
+
+/// <summary>
+///     Handles enabling and disabling mob inherent pointlights when locally attaching to a new mob.
+/// </summary>
+public sealed class ESInherentLightSystem : EntitySystem
+{
+    [Dependency] private readonly PointLightSystem _light = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<LocalPlayerAttachedEvent>(OnPlayerAttach);
+        SubscribeLocalEvent<LocalPlayerDetachedEvent>(OnPlayerDetach);
+    }
+
+    private void OnPlayerAttach(LocalPlayerAttachedEvent ev)
+    {
+        if (!TryComp<ESInherentLightComponent>(ev.Entity, out var light)
+            || light.LightEntity != null)
+            return;
+
+        // Don't enable inherent light if the mob already has a pointlight on itself
+        if (TryComp<PointLightComponent>(ev.Entity, out var selfPointLight) && selfPointLight.Enabled)
+            return;
+
+        light.LightEntity = SpawnAttachedTo(light.LightPrototype, new EntityCoordinates(ev.Entity, Vector2.Zero));
+        _light.SetEnabled(light.LightEntity.Value, true);
+    }
+
+    private void OnPlayerDetach(LocalPlayerDetachedEvent ev)
+    {
+        if (!TryComp<ESInherentLightComponent>(ev.Entity, out var light)
+            || light.LightEntity == null
+            || !TryComp<PointLightComponent>(light.LightEntity, out var inherentPointLight))
+            return;
+
+        QueueDel(light.LightEntity);
+        light.LightEntity = null;
+    }
+}

--- a/Content.Client/_ES/Lighting/ESInherentLightSystem.cs
+++ b/Content.Client/_ES/Lighting/ESInherentLightSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Mirrorcult
+//
+// SPDX-License-Identifier: MIT
+
 using System.Numerics;
 using Robust.Client.GameObjects;
 using Robust.Shared.Map;

--- a/Content.Server/Entry/IgnoredComponents.cs
+++ b/Content.Server/Entry/IgnoredComponents.cs
@@ -21,7 +21,10 @@ namespace Content.Server.Entry
             "HolidayRsiSwap",
             "OptionsVisualizer",
             "AnomalyScannerScreen",
-            "MultipartMachineGhost"
+            "MultipartMachineGhost",
+           // ES START
+            "ESInherentLight",
+            // ES END
         };
     }
 }

--- a/Content.Shared/Pointing/SharedPointingSystem.cs
+++ b/Content.Shared/Pointing/SharedPointingSystem.cs
@@ -6,7 +6,9 @@ namespace Content.Shared.Pointing;
 public abstract class SharedPointingSystem : EntitySystem
 {
     protected readonly TimeSpan PointDuration = TimeSpan.FromSeconds(4);
-    protected readonly float PointKeyTimeMove = 0.1f;
+    // ES START
+    protected readonly float PointKeyTimeMove = 0.3f;
+    // ES END
     protected readonly float PointKeyTimeHover = 0.5f;
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -115,6 +115,12 @@ public sealed partial class MeleeWeaponComponent : Component
     [DataField, AutoNetworkedField]
     public bool SwingLeft;
 
+    // ES START
+    // inverted every swing so that the next
+    // slash goes the other way (instead of from the same dir every time)
+    // clientside
+    public bool SwapNextSwing = false;
+    // ES END
 
     // Sounds
 

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -238,6 +238,9 @@
     regenerationPerSecond: 3
     regenerationInterval: 2.5
   # End Stellar - Sprinting
+  # ES START
+  - type: ESInherentLight
+  # ES END
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
@@ -46,7 +46,7 @@
       types:
         Piercing: 8
     angle: 0
-    animation: WeaponArcThrust
+    wideAnimation: WeaponArcThrust # ES - Animations with Easing
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Fun/darts.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/darts.yml
@@ -34,7 +34,7 @@
       types:
         Piercing: 2
     angle: 0
-    animation: WeaponArcThrust
+    wideAnimation: WeaponArcThrust # ES - Animations with Easing
     soundHit:
       path: /Audio/Weapons/pierce.ogg
   - type: DamageOtherOnHit

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -377,7 +377,7 @@
   - type: MeleeWeapon
     attackRate: 1.5
     angle: 0
-    animation: WeaponArcThrust
+    wideAnimation: WeaponArcThrust # ES - Animations with Easing
     wideAnimationRotation: 90
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -65,7 +65,7 @@
       types:
         Piercing: 12
     angle: 0
-    animation: WeaponArcThrust
+    wideAnimation: WeaponArcThrust # ES - Animations with Easing
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: MeleeRequiresWield
@@ -161,7 +161,7 @@
         Piercing: 15 #you fucking stab em
         Bloodloss: 2 #no way to apply bleed, triangular bayonet wounds are hard to fix(source:that one copypasta)
     angle: 0
-    animation: WeaponArcThrust
+    wideAnimation: WeaponArcThrust # ES - Animations with Easing
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: GunRequiresWield

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -41,7 +41,7 @@
       types:
         Piercing: 12
     angle: 0
-    animation: WeaponArcThrust
+    wideAnimation: WeaponArcThrust # ES - Animations with Easing
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: DamageOtherOnHit

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -34,7 +34,7 @@
       types:
         Blunt: 9
     angle: 60
-    animation: WeaponArcThrust
+    wideAnimation: WeaponArcThrust # ES - Animations with Easing
   - type: StaminaDamageOnHit
     damage: 35
     sound: /Audio/Weapons/egloves.ogg

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -39,7 +39,7 @@
         Blunt: 7
     bluntStaminaDamageFactor: 2.0
     angle: 60
-    animation: WeaponArcThrust
+    wideAnimation: WeaponArcThrust # ES - Animations with Easing
   - type: StaminaDamageOnHit
     damage: 35
     sound: /Audio/Weapons/egloves.ogg

--- a/Resources/Prototypes/_ES/Entities/Mobs/moblights.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/moblights.yml
@@ -1,0 +1,15 @@
+# Inherent point light prototypes that can be attached to mobs using ESInherentLightComponent.
+- type: entity
+  id: ESMobDefaultInherentLight
+  name: inherent light
+  components:
+  - type: PointLight
+    netsync: false
+    color: "#ffffff"
+    energy: 2.5
+    radius: 1.35
+    # ES TODO uncomment once engine lighting done
+    # falloff: 30
+    # curveFactor: 1.0
+    castShadows: false
+    enabled: false

--- a/Resources/Prototypes/_ES/Entities/Mobs/moblights.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/moblights.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Mirrorcult
+#
+# SPDX-License-Identifier: MIT
+
 # Inherent point light prototypes that can be attached to mobs using ESInherentLightComponent.
 - type: entity
   id: ESMobDefaultInherentLight

--- a/Resources/Prototypes/_ST/CosmicCult/Objects/cosmicweapons.yml
+++ b/Resources/Prototypes/_ST/CosmicCult/Objects/cosmicweapons.yml
@@ -96,6 +96,8 @@
     resistanceBypass: true
     angle: 0
     animation: WeaponArcCosmic
+    wideAnimation: WeaponArcThrust # ES - Animations with Easing
+    wideAnimationRotation: -135
     attackRate: 0.62
     damage:
       types:


### PR DESCRIPTION
## About the PR
This is a port of https://github.com/EphemeralSpace/ephemeral-space/pull/137 and https://github.com/EphemeralSpace/ephemeral-space/pull/152.

## Why / Balance
Polish & art direction. Clientlights are important for gameplay visibility, and the animations are art direction.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
MirrorCult
:cl:
- add: Animation Easings & ClientLights, courtesy of MirrorCult/Ephemeral Space