### PR TITLE
Implement wall cutaways

### DIFF
--- a/Content.Stellar.Client/Cutaway/StellarCutawayPostOverlay.cs
+++ b/Content.Stellar.Client/Cutaway/StellarCutawayPostOverlay.cs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Janet Blackquill <uhhadd@gmail.com>
+//
+// SPDX-License-Identifier: LicenseRef-Wallening
+
+using Content.Stellar.Client.WallSmooth;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+
+namespace Content.Stellar.Client.Cutaway;
+
+public sealed class StellarCutawayPostOverlay : Overlay
+{
+    [Dependency] private readonly IEntityManager _entity = default!;
+    private readonly StellarCutawaySystem _cutaway;
+    private readonly StellarWallSmoothSystem _wallSmooth;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    public StellarCutawayPostOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+
+        _cutaway = _entity.System<StellarCutawaySystem>();
+        _wallSmooth = _entity.System<StellarWallSmoothSystem>();
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        foreach (var ent in _cutaway.CutawayTargets)
+        {
+            _wallSmooth.ApplyCorners(ent, false);
+        }
+
+        _cutaway.CutawayTargets.Clear();
+    }
+}

--- a/Content.Stellar.Client/Cutaway/StellarCutawayPreOverlay.cs
+++ b/Content.Stellar.Client/Cutaway/StellarCutawayPreOverlay.cs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Janet Blackquill <uhhadd@gmail.com>
+//
+// SPDX-License-Identifier: LicenseRef-Wallening
+
+using Content.Stellar.Client.WallSmooth;
+using Content.Stellar.Shared.Cutaway;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+
+namespace Content.Stellar.Client.Cutaway;
+
+public sealed class StellarCutawayPreOverlay : Overlay
+{
+    [Dependency] private readonly IEntityManager _entity = default!;
+    private readonly SharedTransformSystem _xform;
+    private readonly StellarCutawayTreeSystem _tree;
+    private readonly StellarWallSmoothSystem _wallSmooth;
+    private readonly StellarCutawaySystem _cutaway;
+
+    private readonly EntityQuery<StellarWallSmoothComponent> _wallSmoothQuery;
+    private readonly EntityQuery<SpriteComponent> _spriteQuery;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowEntities;
+
+    public StellarCutawayPreOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+
+        _xform = _entity.System<SharedTransformSystem>();
+        _tree = _entity.System<StellarCutawayTreeSystem>();
+        _wallSmooth = _entity.System<StellarWallSmoothSystem>();
+        _cutaway = _entity.System<StellarCutawaySystem>();
+
+        _wallSmoothQuery = _entity.GetEntityQuery<StellarWallSmoothComponent>();
+        _spriteQuery = _entity.GetEntityQuery<SpriteComponent>();
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (args.Viewport.Eye is not { } eye)
+            return;
+
+        var targets = _tree.QueryAabb(args.MapId, args.WorldBounds);
+
+        foreach (var target in targets)
+        {
+            var targetPos = _xform.GetWorldPosition(target.Transform);
+
+            var targetOffset = eye.Rotation.RotateVec(eye.Position.Position) - eye.Rotation.RotateVec(targetPos);
+            var offsetAngle = targetOffset.ToAngle();
+            var distance = Angle.ShortestDistance(offsetAngle, StellarCutawayViewerComponent.Angle);
+
+            if (Math.Abs(distance.Theta) > StellarCutawayViewerComponent.AngleDistance)
+                continue;
+
+            if (!_wallSmoothQuery.TryComp(target.Uid, out var wallSmooth) ||
+                !_spriteQuery.TryComp(target.Uid, out var sprite))
+                continue;
+
+            _wallSmooth.ApplyCorners((target.Uid, wallSmooth, sprite), true);
+            _cutaway.CutawayTargets.Add((target.Uid, wallSmooth, sprite));
+        }
+    }
+}

--- a/Content.Stellar.Client/Cutaway/StellarCutawaySystem.cs
+++ b/Content.Stellar.Client/Cutaway/StellarCutawaySystem.cs
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Janet Blackquill <uhhadd@gmail.com>
+//
+// SPDX-License-Identifier: LicenseRef-Wallening
+
+using Content.Stellar.Client.WallSmooth;
+using Content.Stellar.Shared.Cutaway;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Shared.Player;
+
+namespace Content.Stellar.Client.Cutaway;
+
+public sealed class StellarCutawaySystem : EntitySystem
+{
+    [Dependency] private readonly IOverlayManager _overlay = default!;
+    [Dependency] private readonly ISharedPlayerManager _player = default!;
+
+    private StellarCutawayPreOverlay _preOverlay = default!;
+    private StellarCutawayPostOverlay _postOverlay = default!;
+
+    [Access(typeof(StellarCutawayPreOverlay), typeof(StellarCutawayPostOverlay))]
+    public List<Entity<StellarWallSmoothComponent, SpriteComponent>> CutawayTargets = new(64);
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StellarCutawayViewerComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<StellarCutawayViewerComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<StellarCutawayViewerComponent, LocalPlayerAttachedEvent>(OnLocalPlayerAttached);
+        SubscribeLocalEvent<StellarCutawayViewerComponent, LocalPlayerDetachedEvent>(OnLocalPlayerDetached);
+
+        _preOverlay = new();
+        _postOverlay = new();
+    }
+
+    private void OnInit(Entity<StellarCutawayViewerComponent> ent, ref ComponentInit args)
+    {
+        if (_player.LocalSession?.AttachedEntity == ent.Owner)
+            AddOverlays();
+    }
+
+    private void OnShutdown(Entity<StellarCutawayViewerComponent> ent, ref ComponentShutdown args)
+    {
+        if (_player.LocalSession?.AttachedEntity == ent.Owner)
+            RemoveOverlays();
+    }
+
+    private void OnLocalPlayerAttached(Entity<StellarCutawayViewerComponent> ent, ref LocalPlayerAttachedEvent args)
+    {
+        AddOverlays();
+    }
+
+    private void OnLocalPlayerDetached(Entity<StellarCutawayViewerComponent> ent, ref LocalPlayerDetachedEvent args)
+    {
+        RemoveOverlays();
+    }
+
+    private void AddOverlays()
+    {
+        _overlay.AddOverlay(_preOverlay);
+        _overlay.AddOverlay(_postOverlay);
+    }
+
+    private void RemoveOverlays()
+    {
+        _overlay.RemoveOverlay(_preOverlay);
+        _overlay.RemoveOverlay(_postOverlay);
+    }
+}

--- a/Content.Stellar.Client/Cutaway/StellarCutawayTreeComponent.cs
+++ b/Content.Stellar.Client/Cutaway/StellarCutawayTreeComponent.cs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Janet Blackquill <uhhadd@gmail.com>
+//
+// SPDX-License-Identifier: LicenseRef-Wallening
+
+using Content.Stellar.Shared.Cutaway;
+using Robust.Shared.ComponentTrees;
+using Robust.Shared.Physics;
+
+namespace Content.Stellar.Client.Cutaway;
+
+[RegisterComponent]
+public sealed partial class StellarCutawayTreeComponent : Component, IComponentTreeComponent<StellarCutawayComponent>
+{
+    public DynamicTree<ComponentTreeEntry<StellarCutawayComponent>> Tree { get; set; }
+}

--- a/Content.Stellar.Client/Cutaway/StellarCutawayTreeSystem.cs
+++ b/Content.Stellar.Client/Cutaway/StellarCutawayTreeSystem.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Janet Blackquill <uhhadd@gmail.com>
+//
+// SPDX-License-Identifier: LicenseRef-Wallening
+
+using System.Numerics;
+using Content.Stellar.Shared.Cutaway;
+using Robust.Client.GameObjects;
+using Robust.Shared.ComponentTrees;
+using Robust.Shared.Physics;
+
+namespace Content.Stellar.Client.Cutaway;
+
+public sealed class StellarCutawayTreeSystem : ComponentTreeSystem<StellarCutawayTreeComponent, StellarCutawayComponent>
+{
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
+    protected override bool DoFrameUpdate => true;
+    protected override bool DoTickUpdate => false;
+    protected override bool Recursive => false;
+
+    protected override Box2 ExtractAabb(in ComponentTreeEntry<StellarCutawayComponent> entry, Vector2 pos, Angle rot)
+    {
+        return _sprite.CalculateBounds((entry.Uid, Comp<SpriteComponent>(entry.Uid)), pos, rot, default).CalcBoundingBox();
+    }
+}

--- a/Content.Stellar.Client/WallSmooth/StellarWallSmoothComponent.cs
+++ b/Content.Stellar.Client/WallSmooth/StellarWallSmoothComponent.cs
@@ -39,4 +39,7 @@ public sealed partial class StellarWallSmoothComponent : Component
     /// </summary>
     [ViewVariables]
     internal int UpdateGeneration;
+
+    [ViewVariables]
+    public (EntityUid?, Vector2i)? LastPosition;
 }

--- a/Content.Stellar.Shared/Cutaway/StellarCutawayComponent.cs
+++ b/Content.Stellar.Shared/Cutaway/StellarCutawayComponent.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Janet Blackquill <uhhadd@gmail.com>
+//
+// SPDX-License-Identifier: LicenseRef-Wallening
+
+using Robust.Shared.ComponentTrees;
+using Robust.Shared.GameStates;
+using Robust.Shared.Physics;
+
+namespace Content.Stellar.Shared.Cutaway;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class StellarCutawayComponent : Component, IComponentTreeEntry<StellarCutawayComponent>
+{
+    public EntityUid? TreeUid { get; set; }
+    public DynamicTree<ComponentTreeEntry<StellarCutawayComponent>>? Tree { get; set; }
+    public bool AddToTree => true;
+    public bool TreeUpdateQueued { get; set; }
+}

--- a/Content.Stellar.Shared/Cutaway/StellarCutawayViewerComponent.cs
+++ b/Content.Stellar.Shared/Cutaway/StellarCutawayViewerComponent.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Janet Blackquill <uhhadd@gmail.com>
+//
+// SPDX-License-Identifier: LicenseRef-Wallening
+
+using Robust.Shared.GameStates;
+
+namespace Content.Stellar.Shared.Cutaway;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class StellarCutawayViewerComponent : Component
+{
+    public static readonly Angle Angle = new(Math.PI / 2f);
+    public const double AngleDistance = Math.PI / 3f;
+}

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -38,6 +38,7 @@
   - type: MindContainer
   - type: RequireProjectileTarget
     active: False
+  - type: StellarCutawayViewer # Stellar
 
 # The progenitor. This should only container the most basic components possible.
 # Only put things on here if every mob *must* have it. This includes ghosts.

--- a/Resources/Prototypes/_ST/Structures/walls.yml
+++ b/Resources/Prototypes/_ST/Structures/walls.yml
@@ -18,7 +18,8 @@
   - type: StellarWallSmooth
     key: WallSolid
     fullState: wall
-    # downState: downwall # Commented out because it causes tests to fail right now
+    downState: downwall
+  - type: StellarCutaway
   - type: StellarRandomWallSmooth
     randomFullStates:
     - wall
@@ -50,7 +51,8 @@
   - type: StellarWallSmooth
     key: WallSolid
     fullState: wall
-    # downState: downwall # Commented out because it causes tests to fail right now
+    downState: downwall
+  - type: StellarCutaway
   - type: ReinforcedWallReplacementMarker
   - type: Construction
     graph: StellarWalls
@@ -71,7 +73,8 @@
   - type: StellarWallSmooth
     key: WallSolid
     fullState: wall
-    # downState: downwall # Commented out because it causes tests to fail right now
+    downState: downwall
+  - type: StellarCutaway
   - type: GenericVisualizer
     visuals:
       enum.ShuttleWallVisuals.DeconstructionStage:
@@ -153,6 +156,7 @@
   - type: StellarWallSmooth
     key: WallSolid
     fullState: wall
-    # downState: downwall # Commented out because it causes tests to fail right now
+    downState: downwall
+  - type: StellarCutaway
   - type: CosmicCultExamine
     cultistText: cosmic-examine-text-forthecult


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- we have all cutaways now

## Why / Balance
- so you can see stuff under walls

## Technical details
- overlay similar to ES viewcone where sprites are applied in one overlay and removed in a second

## Media
<img width="374" height="377" alt="grafik" src="https://github.com/user-attachments/assets/71fcea54-1b86-447d-9621-28523d623cf8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: sowelipililimute, AftrLite
- add: Walls cutaway to reveal their contents now.
